### PR TITLE
Fix Sim Stats dropdown link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
     <select id="nav-dropdown" onchange="navigatePage(this.value)">
       <option value="index.html">🏠 Home</option>
       <option value="stats.html">📊 Stats</option>
-      <option value="simstats.html">⚙️ Sim Stats</option>
+      <option value="simStats.html">⚙️ Sim Stats</option>
     </select>
 
     <script>

--- a/public/simStats.html
+++ b/public/simStats.html
@@ -40,7 +40,7 @@
   <select id="nav-dropdown" onchange="navigatePage(this.value)">
     <option value="index.html">🏠 Home</option>
     <option value="stats.html">📊 Stats</option>
-    <option value="simstats.html">⚙️ Sim Stats</option>
+    <option value="simStats.html">⚙️ Sim Stats</option>
   </select>
   <script>
     function navigatePage(page) {

--- a/public/stats.html
+++ b/public/stats.html
@@ -22,7 +22,7 @@
     <select id="nav-dropdown" onchange="navigatePage(this.value)">
       <option value="index.html">🏠 Home</option>
       <option value="stats.html">📊 Stats</option>
-      <option value="simstats.html">⚙️ Sim Stats</option>
+      <option value="simStats.html">⚙️ Sim Stats</option>
     </select>
 
     <script>


### PR DESCRIPTION
## Summary
- fix dropdown navigation path for `simStats.html`

## Testing
- `node node_modules/mocha/bin/mocha.js test/unit_test/**/*.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687bba50b214832ea51bf02aa34091fd