### PR TITLE
Optimize db connection usage

### DIFF
--- a/backend/routes/server.js
+++ b/backend/routes/server.js
@@ -10,6 +10,7 @@ const {
   getTopRobbers,
   getTopPolice,
 } = require("../services/gameService");
+const { getConnection } = require("../../db/database");
 const statsRoutes = require("./simstats");
 const { getDynamicRobberGoal } = require("../services/analyticsService");
 
@@ -50,35 +51,48 @@ app.get("/next-turn", async (req, res) => {
   const gameOverMessage = game.isGameOver();
 
   if (gameOverMessage) {
+    let connection;
     try {
-      await addGame({
-        turnCount: game.turns,
-        robberGoal: game.robberGoal,
-        totalJewelValue: game.city.totalJewelValue || 0,
-        winner: gameOverMessage === "Robbers Win!" ? "Robbers" : "Police",
-      });
+      connection = await getConnection();
+      await addGame(
+        {
+          turnCount: game.turns,
+          robberGoal: game.robberGoal,
+          totalJewelValue: game.city.totalJewelValue || 0,
+          winner: gameOverMessage === "Robbers Win!" ? "Robbers" : "Police",
+        },
+        connection
+      );
 
       for (let x = 0; x < 10; x++) {
         for (let y = 0; y < 10; y++) {
           const cell = game.city.cityGrid[x][y];
           if (cell instanceof Robber) {
-            await addPlayer({
-              role: "Robber",
-              lootWorth: cell.totalLootWorth,
-            });
+            await addPlayer(
+              {
+                role: "Robber",
+                lootWorth: cell.totalLootWorth,
+              },
+              connection
+            );
           } else if (cell instanceof Police) {
-            await addPlayer({
-              role: "Police",
-              lootWorth: cell.lootWorth,
-              robbersCaught: cell.robbersCaught,
-              
-            });
+            await addPlayer(
+              {
+                role: "Police",
+                lootWorth: cell.lootWorth,
+                robbersCaught: cell.robbersCaught,
+
+              },
+              connection
+            );
           }
         }
       }
     } catch (err) {
       console.error("Error saving game stats:", err);
       return res.status(500).json({ error: "Failed to save game stats." });
+    } finally {
+      if (connection) await connection.close();
     }
 
     return res.json({
@@ -196,23 +210,31 @@ app.get("/simulate-multiple", async (req, res) => {
       const gameOverMessage = simGame.isGameOver();
       const winner = gameOverMessage === "Robbers Win!" ? "Robbers" : "Police";
 
-      await addGame({
-        turnCount: simGame.turns,
-        robberGoal: simGame.robberGoal,
-        totalJewelValue: simGame.city.totalJewelValue|| 0,
-        winner,
-      });
+      let connection;
+      try {
+        connection = await getConnection();
+        await addGame(
+          {
+            turnCount: simGame.turns,
+            robberGoal: simGame.robberGoal,
+            totalJewelValue: simGame.city.totalJewelValue|| 0,
+            winner,
+          },
+          connection
+        );
 
-      for (let x = 0; x < 10; x++) {
-        for (let y = 0; y < 10; y++) {
-          const cell = simGame.city.cityGrid[x][y];
-          if (cell instanceof Robber) {
-            await addPlayer({ role: "Robber", lootWorth: cell.totalLootWorth });
-          } else if (cell instanceof Police) {
-            await addPlayer({role: "Police", lootWorth: cell.lootWorth, robbersCaught: cell.robbersCaught,
-            });
+        for (let x = 0; x < 10; x++) {
+          for (let y = 0; y < 10; y++) {
+            const cell = simGame.city.cityGrid[x][y];
+            if (cell instanceof Robber) {
+              await addPlayer({ role: "Robber", lootWorth: cell.totalLootWorth }, connection);
+            } else if (cell instanceof Police) {
+              await addPlayer({role: "Police", lootWorth: cell.lootWorth, robbersCaught: cell.robbersCaught}, connection);
+            }
           }
         }
+      } finally {
+        if (connection) await connection.close();
       }
     }
 

--- a/backend/services/gameService.js
+++ b/backend/services/gameService.js
@@ -1,7 +1,7 @@
 const { getConnection } = require("../../db/database");
 
-async function addGame({ turnCount, robberGoal, totalJewelValue, winner }) {
-  const connection = await getConnection();
+async function addGame({ turnCount, robberGoal, totalJewelValue, winner }, conn) {
+  const connection = conn || (await getConnection());
   if (!connection) return;
 
   try {
@@ -16,12 +16,12 @@ async function addGame({ turnCount, robberGoal, totalJewelValue, winner }) {
   } catch (err) {
     console.error("Error inserting game:", err);
   } finally {
-    if (connection) await connection.close();
+    if (!conn && connection) await connection.close();
   }
 }
 
-async function addPlayer({ role, lootWorth = 0, robbersCaught = 0 }) {
-  const connection = await getConnection();
+async function addPlayer({ role, lootWorth = 0, robbersCaught = 0 }, conn) {
+  const connection = conn || (await getConnection());
   if (!connection) return;
 
   try {
@@ -52,7 +52,7 @@ async function addPlayer({ role, lootWorth = 0, robbersCaught = 0 }) {
   } catch (err) {
     console.error("Error adding player:", err);
   } finally {
-    await connection.close();
+    if (!conn && connection) await connection.close();
   }
 }
 


### PR DESCRIPTION
## Summary
- allow `addGame` and `addPlayer` to reuse an existing DB connection
- share one connection in `/next-turn` for saving the game and players
- reuse the same connection per game in `/simulate-multiple`
- import `getConnection` in the server routes

## Testing
- `npm run lint` *(fails: 3 errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bbc9407e0832ea872f74a641de7b5